### PR TITLE
fix: using yonius options typings

### DIFF
--- a/types/order.d.ts
+++ b/types/order.d.ts
@@ -1,4 +1,4 @@
-import { Options } from "yonius";
+import { APIOptions } from "yonius";
 
 export interface Address {
     readonly firstName: string;
@@ -62,7 +62,7 @@ export interface OrderPatch {
 }
 
 export declare class OrderAPI {
-    listOrders(options: Options): Order[];
+    listOrders(options: APIOptions): Order[];
     getOrder(id: string): Order;
     createOrder(payload: OrderCreate): Order;
     updateOrder(id: string, payload: OrderPatch): Order;

--- a/types/order.d.ts
+++ b/types/order.d.ts
@@ -23,10 +23,9 @@ export enum Status {
 export interface Order {
     readonly id: string;
     readonly user: string;
-    readonly name: string;
     readonly email: string;
-    readonly shippingAddress: string;
-    readonly billingAddress: string;
+    readonly shippingAddress: Address;
+    readonly billingAddress: Address;
     readonly productQuery: string;
     readonly amount: number;
     readonly currency: string;
@@ -39,10 +38,9 @@ export interface Order {
 export interface OrderCreate {
     readonly id?: number;
     readonly user: string;
-    readonly name: string;
     readonly email: string;
-    readonly shippingAddress: string;
-    readonly billingAddress: string;
+    readonly shippingAddress: Address;
+    readonly billingAddress: Address;
     readonly productQuery: string;
     readonly amount: number;
     readonly currency?: string;
@@ -54,10 +52,9 @@ export interface OrderCreate {
 
 export interface OrderPatch {
     readonly user?: string;
-    readonly name?: string;
     readonly email?: string;
-    readonly shippingAddress?: string;
-    readonly billingAddress?: string;
+    readonly shippingAddress?: Address;
+    readonly billingAddress?: Address;
     readonly productQuery?: string;
     readonly amount?: number;
     readonly currency?: string;

--- a/types/order.d.ts
+++ b/types/order.d.ts
@@ -1,17 +1,12 @@
-export interface Options {
-    readonly fields?: string[],
-    readonly eager?: boolean,
-    readonly eagerL?: boolean,
-    readonly map?: boolean,
-    readonly rules?: boolean,
-    readonly meta?: boolean,
-    readonly build?: boolean,
-    readonly fill?: boolean,
-    readonly resolveA?: boolean,
-    readonly skip?: number,
-    readonly limit?: number,
-    readonly sort?: unknown[][],
-    readonly raiseE?: boolean,
+import { Options } from "yonius";
+
+export interface Address {
+    readonly firstName: string;
+    readonly lastName: string;
+    readonly address: string;
+    readonly postcode: string;
+    readonly country: string;
+    readonly state: string;
 }
 
 export enum Status {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-registry-api-js/pull/10#discussion_r575074145 |
| Dependencies | https://github.com/hivesolutions/yonius/pull/29 |
| Decisions | Using yonius `Options` type declarations. <br> Using Address type and removed name from Order. |
| Animated GIF | -- |
