### PR TITLE
Feat: create query and product for drop single request

### DIFF
--- a/js/drop.js
+++ b/js/drop.js
@@ -36,7 +36,7 @@ export const DropAPI = superclass =>
             return productDrop;
         }
 
-        async createProductDropAndQueryDrop(id, payload) {
+        async createProductDropQueryDrop(id, payload) {
             const url = this.baseUrl + `drops/${id}/product_query`;
             const productDrop = await this.post(url, { dataJ: payload });
             return productDrop;

--- a/js/drop.js
+++ b/js/drop.js
@@ -36,6 +36,12 @@ export const DropAPI = superclass =>
             return productDrop;
         }
 
+        async createProductDropAndQueryDrop(id, payload) {
+            const url = this.baseUrl + `drops/${id}/product_query`;
+            const productDrop = await this.post(url, { dataJ: payload });
+            return productDrop;
+        }
+
         async deleteProductDropDrop(id, product) {
             const url = this.baseUrl + `drops/${id}/product/${product}`;
             const productDrop = await this.delete(url);

--- a/js/product-drop.js
+++ b/js/product-drop.js
@@ -1,3 +1,5 @@
+import QueryAPI from "./query";
+
 export const ProductDropAPI = superclass =>
     class extends superclass {
         async listProductDrops(options = {}) {
@@ -7,6 +9,11 @@ export const ProductDropAPI = superclass =>
         }
 
         async createProductDrop(payload) {
+            if (payload.query && typeof payload.query === "string") {
+                const query = await QueryAPI.createQuery({ query: payload.query });
+                payload.queries = [query.id];
+                delete payload.query;
+            }
             const url = this.baseUrl + "product_drops";
             const productDrop = await this.post(url, { dataJ: payload });
             return productDrop;

--- a/js/product-drop.js
+++ b/js/product-drop.js
@@ -1,5 +1,3 @@
-import QueryAPI from "./query";
-
 export const ProductDropAPI = superclass =>
     class extends superclass {
         async listProductDrops(options = {}) {

--- a/js/product-drop.js
+++ b/js/product-drop.js
@@ -9,11 +9,6 @@ export const ProductDropAPI = superclass =>
         }
 
         async createProductDrop(payload) {
-            if (payload.query && typeof payload.query === "string") {
-                const query = await QueryAPI.createQuery({ query: payload.query });
-                payload.queries = [query.id];
-                delete payload.query;
-            }
             const url = this.baseUrl + "product_drops";
             const productDrop = await this.post(url, { dataJ: payload });
             return productDrop;

--- a/types/drop.d.ts
+++ b/types/drop.d.ts
@@ -38,6 +38,12 @@ export interface DropPatch {
     readonly products?: string[];
 }
 
+export interface ProductDropQueryCreate {
+    readonly name: string;
+    readonly productCollection: string;
+    readonly query: string;
+}
+
 export declare class DropAPI {
     listDrops(options: APIOptions): Promise<Drop[]>;
     createDrop(payload: DropCreate): Promise<Drop>;
@@ -45,5 +51,6 @@ export declare class DropAPI {
     updateDrop(id: string, payload: DropPatch): Promise<Drop>;
     deleteDrop(id: string): Promise<void>;
     createProductDropDrop(id: string, payload: ProductDropCreate): Promise<ProductDrop>;
+    createProductDropQueryDrop(id: string, payload: ProductDropQueryCreate): Promise<ProductDrop>;
     deleteProductDropDrop(id: string, product: string): Promise<void>;
 }

--- a/types/product-drop.d.ts
+++ b/types/product-drop.d.ts
@@ -4,6 +4,8 @@ import { Query } from "./query";
 
 export interface ProductDrop {
     readonly id: string;
+    readonly name: string;
+    readonly drop: string;
     readonly channel: string;
     readonly productCollection: string;
     readonly query: Query;
@@ -15,6 +17,7 @@ export interface ProductDrop {
 
 export interface ProductDropCreate {
     readonly id?: number;
+    readonly name?: string;
     readonly productCollection: string;
     readonly queries: string[];
     readonly created?: number;
@@ -23,6 +26,7 @@ export interface ProductDropCreate {
 }
 
 export interface ProductDropPatch {
+    readonly name?: string;
     readonly productCollection?: string;
     readonly queries?: string[];
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | https://github.com/ripe-tech/ripe-twitch/pull/96 |
| Decisions | The naming is what I thought was best considering the template naming we follow of `actionResourceParent` so with `action = create`, `resource = ProductDrop + Query = ProductDropAndQuery` and `parent = Drop`  which would be `createProductDropAndQueryDrop` |

