### PR TITLE
Property setter to change props (like tokens) during execution

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -26,6 +26,7 @@ export class API extends mix(BaseAPI).with(
         this.token = conf("TOKEN", null);
         this.baseUrl = kwargs.baseUrl === undefined ? this.baseUrl : kwargs.baseUrl;
         this.token = kwargs.token === undefined ? this.token : kwargs.token;
+        this.tokenTwitch = kwargs.tokenTwitch === undefined ? null : kwargs.tokenTwitch;
     }
 
     static async load() {
@@ -39,7 +40,9 @@ export class API extends mix(BaseAPI).with(
         const auth = options.kwargs.auth === undefined ? true : options.kwargs.auth;
         delete options.kwargs.auth;
         if (auth) {
-            options.headers.Authorization = `Bearer ${this.token}`;
+            if (this.token) options.headers.Authorization = `Bearer ${this.token}`;
+            if (this.tokenTwitch)
+                { options.headers.AuthorizationTwitch = `Bearer ${this.tokenTwitch}`; }
         }
     }
 
@@ -47,6 +50,12 @@ export class API extends mix(BaseAPI).with(
         const url = this.baseUrl + "info";
         const contents = await this.get(url);
         return contents;
+    }
+
+    set(kwargs = {}) {
+        this.baseUrl = kwargs.baseUrl === undefined ? this.baseUrl : kwargs.baseUrl;
+        this.token = kwargs.token === undefined ? this.token : kwargs.token;
+        this.tokenTwitch = kwargs.tokenTwitch === undefined ? this.tokenTwitch : kwargs.tokenTwitch;
     }
 }
 


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | API is initialized once, but once the twitch `onAuthorize` callback is called with user-specific information, like the JWT token, API properties may need updating. Instead of creating a setter for each property, like `setToken`, I have created a generic `set` similar to the constructor.  |

